### PR TITLE
Remove background color from `.container`

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -267,7 +267,6 @@ h1 {
     position: relative;
     max-width: 1900px; /* Increased from 500px */
     width: 100%;
-    background: #fff;
     margin: 0 auto; /* Changed from '0 15px' to center the container */
     padding: 20px 0px; /* Increased padding */
     border-radius: 7px;


### PR DESCRIPTION
This change fixes a bug with a colored shadow being overridden by `.container` due to the `background: #fff` property

![image](https://github.com/user-attachments/assets/c10be3a7-df98-4aa3-9a98-543e8c32c2e2)